### PR TITLE
Escape single quotes in PR creation.

### DIFF
--- a/apps/cli/src/actions/submit/submit_action.ts
+++ b/apps/cli/src/actions/submit/submit_action.ts
@@ -11,7 +11,7 @@ import {
   footerFooter,
   footerTitle,
 } from '../create_pr_body_footer';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 // eslint-disable-next-line max-lines-per-function
 export async function submitAction(
@@ -159,13 +159,13 @@ export async function submitAction(
     const prFooterChanged = !prInfo.body?.includes(footer);
 
     if (prFooterChanged) {
-      execSync(
-        `gh pr edit ${prInfo.number} --body '${updatePrBodyFooter(
-          prInfo.body,
-          footer
-        )}'
-      `
-      );
+      execFileSync('gh', [
+        'pr',
+        'edit',
+        `${prInfo.number}`,
+        '--body',
+        updatePrBodyFooter(prInfo.body, footer),
+      ]);
 
       context.splog.info(
         `${chalk.green(branch)}: ${prInfo.url} (${

--- a/apps/cli/src/actions/submit/submit_prs.ts
+++ b/apps/cli/src/actions/submit/submit_prs.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import { TContext } from '../../lib/context';
 import { ExitFailedError } from '../../lib/errors';
 import { Unpacked } from '../../lib/utils/ts_helpers';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 
 export type TPRSubmissionInfo = t.UnwrapSchemaMap<
   typeof API_ROUTES.submitPullRequests.params
@@ -148,13 +148,18 @@ function getPrNumberFromUrl(url: string): number {
 function createNewPrOnGitHub(
   request: TSubmittedPRRequest
 ): TSubmittedPRResponse {
-  const result = execSync(
-    `gh pr create --head '${request.head}' \
-                --base '${request.base}' \
-                --title '${request.title?.replace(/'/g, `'\\''`)}' \
-                --body '${request.body?.replace(/'/g, `'\\''`)}' \
-                ${request.draft ? '--draft' : ''}`
-  )
+  const result = execFileSync('gh', [
+    'pr',
+    'create',
+    '--head',
+    request.head,
+    '--base',
+    request.base,
+    '--title',
+    request.title ?? '',
+    '--body',
+    request.body ?? '',
+  ])
     .toString()
     .trim();
 

--- a/apps/cli/src/actions/submit/submit_prs.ts
+++ b/apps/cli/src/actions/submit/submit_prs.ts
@@ -151,8 +151,8 @@ function createNewPrOnGitHub(
   const result = execSync(
     `gh pr create --head '${request.head}' \
                 --base '${request.base}' \
-                --title '${request.title}' \
-                --body '${request.body}' \
+                --title '${request.title?.replace(/'/g, `'\\''`)}' \
+                --body '${request.body?.replace(/'/g, `'\\''`)}' \
                 ${request.draft ? '--draft' : ''}`
   )
     .toString()


### PR DESCRIPTION
Previously, quotes in PR titles and bodies would break the PR submit shell script:
```
/bin/sh: -c: line 0: unexpected EOF while looking for matching ``'
/bin/sh: -c: line 3: syntax error: unexpected end of file
ERROR: Command failed: gh pr edit 7 --body 'here's the body`a"sdc
'
      
/bin/sh: -c: line 0: unexpected EOF while looking for matching ``'
/bin/sh: -c: line 3: syntax error: unexpected end of file
```

This PR replaces vulnerable `execSync` calls with `execFileSync` which avoids the shell.
