### PR TITLE
Don't try to sync trunk prInfo.

### DIFF
--- a/apps/cli/src/actions/sync_pr_info.ts
+++ b/apps/cli/src/actions/sync_pr_info.ts
@@ -13,10 +13,12 @@ export async function syncPrInfo(
   }
 
   const upsertInfo = await getPrInfoForBranches(
-    branchNames.map((branchName) => ({
-      branchName,
-      prNumber: context.engine.getPrInfo(branchName)?.number,
-    }))
+    branchNames
+      .filter((branchName) => !context.engine.isTrunk(branchName))
+      .map((branchName) => ({
+        branchName,
+        prNumber: context.engine.getPrInfo(branchName)?.number,
+      }))
   );
 
   upsertPrInfoForBranches(upsertInfo, context.engine);


### PR DESCRIPTION
**Summary**

Skips the PR info fetch for the trunk branch, because a PR's head can't be the trunk.

Currently, `gs sync` always shows the message:
```
no pull requests found for branch "main"
```


# Stack


1. #2
1. #21 👈
2. #22 