### PR TITLE
 Fix gs sync: avoid branch switch when pulling trunk, fetch PR info concurrently

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,8 +6,8 @@
   "files.insertFinalNewline": true,
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-},
+    "source.fixAll.eslint": "explicit"
+  },
   "files.exclude": {
     "**/.DS_Store": true,
     "**/.git": true,

--- a/apps/cli/src/actions/submit/submit_action.ts
+++ b/apps/cli/src/actions/submit/submit_action.ts
@@ -76,6 +76,7 @@ export async function submitAction(
     chalk.blueBright(`🥞 Validating that this gs stack is ready to submit...`)
   );
   context.splog.newline();
+
   await validateBranchesToSubmit(branchNames, context);
 
   context.splog.info(

--- a/apps/cli/src/actions/submit/validate_branches.ts
+++ b/apps/cli/src/actions/submit/validate_branches.ts
@@ -98,6 +98,7 @@ function validateBaseRevisions(branchNames: string[], context: TContext): void {
             branchName
           )} has fallen behind trunk. You may encounter conflicts if you attempt to merge it.`
         );
+        context.splog.newline();
       }
     } else if (validatedBranches.has(parentBranchName)) {
       if (!context.engine.isBranchFixed(branchName)) {

--- a/apps/cli/src/actions/sync/sync.ts
+++ b/apps/cli/src/actions/sync/sync.ts
@@ -107,7 +107,8 @@ export async function pullTrunk(
   context.splog.info(
     `🌲 Pulling ${chalk.cyan(context.engine.trunk)} from remote...`
   );
-  const pullResult = context.engine.pullTrunk();
+  const pullResult = context.engine.pullTrunk(context);
+  context.splog.info(`after pull trunk: ` + new Date());
   if (pullResult !== 'PULL_CONFLICT') {
     context.splog.info(
       pullResult === 'PULL_UNNEEDED'

--- a/apps/cli/src/actions/sync/sync.ts
+++ b/apps/cli/src/actions/sync/sync.ts
@@ -107,8 +107,7 @@ export async function pullTrunk(
   context.splog.info(
     `🌲 Pulling ${chalk.cyan(context.engine.trunk)} from remote...`
   );
-  const pullResult = context.engine.pullTrunk(context);
-  context.splog.info(`after pull trunk: ` + new Date());
+  const pullResult = context.engine.pullTrunk();
   if (pullResult !== 'PULL_CONFLICT') {
     context.splog.info(
       pullResult === 'PULL_UNNEEDED'

--- a/apps/cli/src/actions/sync/sync.ts
+++ b/apps/cli/src/actions/sync/sync.ts
@@ -29,7 +29,7 @@ export async function syncAction(
   const branchesToSyncPrInfo = context.engine.allBranchNames.filter(
     (branchName) =>
       !context.engine.isTrunk(branchName) &&
-      !context.engine.isBranchTracked(branchName)
+      context.engine.isBranchTracked(branchName)
   );
   await syncPrInfo(branchesToSyncPrInfo, context);
 

--- a/apps/cli/src/lib/api/pr_info.ts
+++ b/apps/cli/src/lib/api/pr_info.ts
@@ -31,36 +31,38 @@ export async function getPrInfoForBranches(
   });
 
   try {
-    const response: TPRInfoToUpsert = [];
+    // Gh CLI allows for looking up by pr number or branch name
+    const results = await Promise.all(
+      [...existingPrInfo.keys(), ...branchesWithoutPrInfo].map(async (prId) => {
+        try {
+          const pr = JSON.parse(
+            execSync(
+              `gh pr view ${prId} --json state,url,title,body,number,headRefName,baseRefName,reviewDecision,isDraft`
+            ).toString()
+          );
 
-    // Gh CLI allows for looking up by pr number of branch name
-    for (const prId of [...existingPrInfo.keys(), ...branchesWithoutPrInfo]) {
-      try {
-        const pr = await JSON.parse(
-          execSync(
-            `gh pr view ${prId} --json state,url,title,body,number,headRefName,baseRefName,reviewDecision,isDraft`
-          ).toString()
-        );
+          pr.prNumber = pr.number;
+          delete pr.number;
 
-        pr.prNumber = pr.number;
-        delete pr.number;
+          if (pr.reviewDecision === '') {
+            pr.reviewDecision = undefined;
+          }
 
-        if (pr.reviewDecision === '') {
-          pr.reviewDecision = undefined;
+          return pr;
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message.includes('no pull requests found')
+          ) {
+            return null;
+          }
+
+          throw error;
         }
+      })
+    );
 
-        response.push(pr);
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          error.message.includes('no pull requests found')
-        ) {
-          continue;
-        }
-
-        throw error;
-      }
-    }
+    const response: TPRInfoToUpsert = results.filter((pr) => pr !== null);
 
     return response.filter((pr) => {
       const branchNameIfAssociated = existingPrInfo.get(pr.prNumber);

--- a/apps/cli/src/lib/engine/engine.ts
+++ b/apps/cli/src/lib/engine/engine.ts
@@ -26,7 +26,6 @@ import {
 import { validateOrFixParentBranchRevision } from './parse_branches_and_meta';
 import { TScopeSpec } from './scope_spec';
 import fjsh from 'fast-json-stable-hash';
-import { TContext } from '../context';
 
 export type TEngine = {
   debug: string;
@@ -132,9 +131,7 @@ export type TEngine = {
   branchMatchesRemote: (branchName: string) => boolean;
 
   pushBranch: (branchName: string, forcePush: boolean) => void;
-  pullTrunk: (
-    context?: TContext
-  ) => 'PULL_DONE' | 'PULL_UNNEEDED' | 'PULL_CONFLICT';
+  pullTrunk: () => 'PULL_DONE' | 'PULL_UNNEEDED' | 'PULL_CONFLICT';
   hardReset: (sha?: string) => void;
   resetTrunkToRemote: () => void;
   clean: () => void;
@@ -915,56 +912,22 @@ export function composeEngine({
       assertBranchIsValidAndNotTrunkAndGetMeta(branchName);
       git.pushBranch({ remote, branchName, noVerify, forcePush });
     },
-    pullTrunk: (context?: TContext) => {
-      if (context) {
-        context.splog.info('before prune: ' + new Date());
-      }
+    pullTrunk: () => {
       git.pruneRemote(remote);
-      if (context) {
-        context.splog.info('after prune: ' + new Date());
-      }
-      const currentBranchName = getCurrentBranchOrThrow();
       const trunkName = assertTrunk();
       const oldTrunkCachedMeta = cache.branches[trunkName];
-      try {
-        git.switchBranch(trunkName);
-        if (context) {
-          context.splog.info('before pull: ' + new Date());
-        }
-        const result = git.pullBranch(remote, trunkName);
-        if (context) {
-          context.splog.info('after pull: ' + new Date());
-        }
-        if (result === 'CONFLICT') {
-          git.switchBranch(currentBranchName);
-          return 'PULL_CONFLICT';
-        }
-        if (context) {
-          context.splog.info('before getSha: ' + new Date());
-        }
-        const newTrunkRevision = git.getShaOrThrow(trunkName);
-        if (context) {
-          context.splog.info('after getSha: ' + new Date());
-        }
-        cache.branches[trunkName] = {
-          ...oldTrunkCachedMeta,
-          branchRevision: newTrunkRevision,
-        };
-        if (context) {
-          context.splog.info('after destructure: ' + new Date());
-        }
-        return oldTrunkCachedMeta.branchRevision === newTrunkRevision
-          ? 'PULL_UNNEEDED'
-          : 'PULL_DONE';
-      } finally {
-        if (context) {
-          context.splog.info('before switch: ' + new Date());
-        }
-        git.switchBranch(currentBranchName);
-        if (context) {
-          context.splog.info('after switch: ' + new Date());
-        }
+      const result = git.fetchTrunk(remote, trunkName);
+      if (result === 'CONFLICT') {
+        return 'PULL_CONFLICT';
       }
+      const newTrunkRevision = git.getShaOrThrow(trunkName);
+      cache.branches[trunkName] = {
+        ...oldTrunkCachedMeta,
+        branchRevision: newTrunkRevision,
+      };
+      return oldTrunkCachedMeta.branchRevision === newTrunkRevision
+        ? 'PULL_UNNEEDED'
+        : 'PULL_DONE';
     },
     hardReset: git.hardReset,
     resetTrunkToRemote: () => {

--- a/apps/cli/src/lib/git/git.ts
+++ b/apps/cli/src/lib/git/git.ts
@@ -37,7 +37,7 @@ import { logLong } from './log';
 import { getMergeBase } from './merge_base';
 import { getUnmergedFiles, getRebaseHead } from './merge_conflict_help';
 import { pruneRemote } from './prune_remote';
-import { pullBranch } from './pull_branch';
+import { fetchTrunk, pullBranch } from './pull_branch';
 import { pushBranch } from './push_branch';
 import {
   rebase,
@@ -100,6 +100,7 @@ function composeGitInternal() {
     pruneRemote,
     showCommits,
     getFileContents,
+    fetchTrunk,
     pullBranch,
     pushBranch,
     rebaseInProgress,

--- a/apps/cli/src/lib/git/pull_branch.ts
+++ b/apps/cli/src/lib/git/pull_branch.ts
@@ -1,6 +1,31 @@
 import { CommandFailedError, runGitCommand } from './runner';
 
 /**
+ * Fast-forwards a local branch ref to match remote without switching branches.
+ * Returns OK if the branch was fast-forwarded successfully.
+ * Returns CONFLICT if it could not be fast-forwarded.
+ */
+export function fetchTrunk(
+  remote: string,
+  branchName: string
+): 'OK' | 'CONFLICT' {
+  try {
+    runGitCommand({
+      args: [`fetch`, remote, `${branchName}:${branchName}`],
+      options: { stdio: 'pipe' },
+      onError: 'throw',
+      resource: 'fetchTrunk',
+    });
+    return 'OK';
+  } catch (e: unknown) {
+    if (e instanceof CommandFailedError) {
+      return 'CONFLICT';
+    }
+    throw e;
+  }
+}
+
+/**
  * Returns OK if the branch was fast-forwarded successfully
  * Returns CONFLICT if it could not be fast-forwarded
  */


### PR DESCRIPTION
# Summary

- `pullTrunk` previously switched to the trunk branch to run `git pull`, causing unnecessary branch switches and noisy output. Replaced with `git fetch origin main:main` which fast-forwards the local ref without switching branches.
- PR info fetching in `getPrInfoForBranches` was sequential. Switched to `Promise.all` so all `gh pr view` calls run concurrently.
- Fixed a bug where `syncPrInfo` was filtering to *untracked* branches instead of tracked ones (inverted condition).
- Added a newline after the "fallen behind trunk" warning in submit validation for cleaner output.

# Stack

1. #25 👈
2. #26
3. #27
4. #28
5. #29
6. #30
7. #31
8. #32 