### PR TITLE
Fix gs sync: update remote tracking ref before resetting trunk

### DIFF
--- a/apps/cli/src/actions/submit/submit_action.ts
+++ b/apps/cli/src/actions/submit/submit_action.ts
@@ -178,13 +178,9 @@ export async function submitAction(
 
       if (hasPrFooterChanged && prInfo.number) {
         const newPrFooter = createPrBodyFooter(prStackToSubmit, prInfo.number);
-        execFileSync('gh', [
-          'pr',
-          'edit',
-          `${prInfo.number}`,
-          '--body',
-          updatePrBodyFooter(prInfo.body, newPrFooter),
-        ]);
+        execFileSync('gh', ['pr', 'edit', branch, '--body', '-'], {
+          input: updatePrBodyFooter(prInfo.body, newPrFooter),
+        });
       }
       context.splog.info(
         `${chalk.green(branch)}: ${prInfo.url} (${

--- a/apps/cli/src/lib/engine/engine.ts
+++ b/apps/cli/src/lib/engine/engine.ts
@@ -936,6 +936,7 @@ export function composeEngine({
       const oldTrunkCachedMeta = cache.branches[trunkName];
 
       try {
+        git.fetchRemoteTrackingBranch(remote, trunkName);
         git.switchBranch(trunkName);
         const remoteTrunkRevision = git.getShaOrThrow(`${remote}/${trunkName}`);
         git.hardReset(remoteTrunkRevision);

--- a/apps/cli/src/lib/git/git.ts
+++ b/apps/cli/src/lib/git/git.ts
@@ -37,7 +37,11 @@ import { logLong } from './log';
 import { getMergeBase } from './merge_base';
 import { getUnmergedFiles, getRebaseHead } from './merge_conflict_help';
 import { pruneRemote } from './prune_remote';
-import { fetchTrunk, pullBranch } from './pull_branch';
+import {
+  fetchRemoteTrackingBranch,
+  fetchTrunk,
+  pullBranch,
+} from './pull_branch';
 import { pushBranch } from './push_branch';
 import {
   rebase,
@@ -101,6 +105,7 @@ function composeGitInternal() {
     showCommits,
     getFileContents,
     fetchTrunk,
+    fetchRemoteTrackingBranch,
     pullBranch,
     pushBranch,
     rebaseInProgress,

--- a/apps/cli/src/lib/git/pull_branch.ts
+++ b/apps/cli/src/lib/git/pull_branch.ts
@@ -1,5 +1,17 @@
 import { CommandFailedError, runGitCommand } from './runner';
 
+export function fetchRemoteTrackingBranch(
+  remote: string,
+  branchName: string
+): void {
+  runGitCommand({
+    args: [`fetch`, remote, branchName],
+    options: { stdio: 'pipe' },
+    onError: 'throw',
+    resource: 'fetchRemoteTrackingBranch',
+  });
+}
+
 /**
  * Fast-forwards a local branch ref to match remote without switching branches.
  * Returns OK if the branch was fast-forwarded successfully.


### PR DESCRIPTION
# Summary

- When `gs sync` couldn't fast-forward trunk and fell back to `resetTrunkToRemote`, it was reading a stale `origin/main` SHA because the failed fetch never updated the remote tracking ref. Added a `git fetch origin main` before the reset to ensure `origin/main` is up to date first.
- Changed `gh pr edit --body <value>` to pass the body via stdin (`--body -`) to avoid issues with large or special-character bodies being passed as a CLI argument.

# Stack

1. #25
1. #26
1. #27 👈
2. #28
3. #29
4. #30
5. #31
6. #32 