### PR TITLE
Show git output during push and rebase

### DIFF
--- a/apps/cli/src/lib/git/push_branch.ts
+++ b/apps/cli/src/lib/git/push_branch.ts
@@ -17,7 +17,7 @@ export function pushBranch(opts: {
       opts.branchName,
       ...(opts.noVerify ? ['--no-verify'] : []),
     ],
-    options: { stdio: 'pipe' },
+    options: { stdio: 'inherit' },
     onError: 'throw',
     resource: 'pushBranch',
   });

--- a/apps/cli/src/lib/git/rebase.ts
+++ b/apps/cli/src/lib/git/rebase.ts
@@ -62,7 +62,7 @@ function rebaseInternal(params: {
   try {
     runGitCommand({
       args: ['rebase', ...params.args],
-      options: { stdio: 'pipe', ...params.options },
+      options: { stdio: 'inherit', ...params.options },
       onError: 'throw',
       resource: params.resource,
     });


### PR DESCRIPTION
# Summary

`git push` and `git rebase` were using `stdio: 'pipe'`, swallowing all output including pre-push hook messages (e.g. linters, Bazel checks) and rebase hook output.

Changed both to `stdio: 'inherit'` so output is visible during `gs submit` and `gs restack`.

# Stack

1. #25
1. #26
1. #27
1. #28 👈
2. #29
3. #30
4. #31
5. #32 