### PR TITLE
Fix gs submit: use REST API for PR updates to avoid GraphQL deprecation error

### DIFF
--- a/apps/cli/src/actions/submit/submit_action.ts
+++ b/apps/cli/src/actions/submit/submit_action.ts
@@ -178,9 +178,20 @@ export async function submitAction(
 
       if (hasPrFooterChanged && prInfo.number) {
         const newPrFooter = createPrBodyFooter(prStackToSubmit, prInfo.number);
-        execFileSync('gh', ['pr', 'edit', branch, '--body', '-'], {
-          input: updatePrBodyFooter(prInfo.body, newPrFooter),
-        });
+        execFileSync(
+          'gh',
+          [
+            'api',
+            `repos/${context.repoConfig.getRepoOwner()}/${context.repoConfig.getRepoName()}/pulls/${
+              prInfo.number
+            }`,
+            '--method',
+            'PATCH',
+            '--field',
+            `body=${updatePrBodyFooter(prInfo.body, newPrFooter)}`,
+          ],
+          { stdio: ['pipe', 'pipe', 'pipe'] }
+        );
       }
       context.splog.info(
         `${chalk.green(branch)}: ${prInfo.url} (${

--- a/apps/cli/src/actions/submit/submit_action.ts
+++ b/apps/cli/src/actions/submit/submit_action.ts
@@ -182,9 +182,7 @@ export async function submitAction(
           'gh',
           [
             'api',
-            `repos/${context.repoConfig.getRepoOwner()}/${context.repoConfig.getRepoName()}/pulls/${
-              prInfo.number
-            }`,
+            `repos/{owner}/{repo}/pulls/${prInfo.number}`,
             '--method',
             'PATCH',
             '--field',

--- a/apps/cli/src/actions/submit/submit_prs.ts
+++ b/apps/cli/src/actions/submit/submit_prs.ts
@@ -114,7 +114,18 @@ async function submitPrToGithub({
     const prBaseChanged = prInfo.baseRefName !== request.base;
 
     if (prBaseChanged) {
-      execSync(`gh pr edit ${prInfo.headRefName} --base ${request.base}`);
+      execFileSync(
+        'gh',
+        [
+          'api',
+          `repos/{owner}/{repo}/pulls/${prInfo.number}`,
+          '--method',
+          'PATCH',
+          '--field',
+          `base=${request.base}`,
+        ],
+        { stdio: ['pipe', 'pipe', 'pipe'] }
+      );
     }
 
     return {


### PR DESCRIPTION
# Summary

GitHub's GraphQL API returns a deprecation warning for "Projects (classic)" alongside PR mutation responses, causing `gh pr edit` to exit with a non-zero code and fail the submit.

Replaced both `gh pr edit` calls (PR body update and base branch update) with `gh api --method PATCH` against the REST API, which doesn't touch `projectCards` and has no deprecation warning.

# Stack

1. #25
1. #26
1. #27
1. #28
1. #29 👈
2. #30
3. #31
4. #32 