### PR TITLE
Enable restack by default in gs sync

### DIFF
--- a/apps/cli/src/commands/repo_sync.ts
+++ b/apps/cli/src/commands/repo_sync.ts
@@ -33,7 +33,7 @@ const args = {
   restack: {
     describe: `Restack the current stack and any stacks with deleted branches.`,
     demandOption: false,
-    default: false,
+    default: true,
     type: 'boolean',
     alias: 'r',
   },


### PR DESCRIPTION
# Summary

`gs sync` was not restacking branches after pulling trunk, requiring a separate `gs restack` step. Changed `--restack` to default to `true` to match Graphite's behavior. Use `--no-restack` to skip.

# Stack

1. #25
1. #26
1. #27
1. #28
1. #29
1. #30 👈
2. #31
3. #32 