### PR TITLE
Fix gs submit: remove duplicate -d alias from --draft

### DIFF
--- a/apps/cli/src/commands/submit.ts
+++ b/apps/cli/src/commands/submit.ts
@@ -28,7 +28,6 @@ export const args = {
       'If set, marks PR as draft. If --no-interactive is true, new PRs will be created in draft mode.',
     type: 'boolean',
     default: false,
-    alias: 'd',
   },
   publish: {
     describe:


### PR DESCRIPTION
# Summary

`--draft` and `--downstack` both declared `alias: 'd'`, making `-d` ambiguous.

Removed the alias from `--draft` as a partial fix.

# Stack

1. #25
1. #26
1. #27
1. #28
1. #29
1. #30
1. #31 👈
2. #32 