### PR TITLE
Make "Skip" the default option in PR body prompt

### DIFF
--- a/apps/cli/src/actions/submit/pr_body.ts
+++ b/apps/cli/src/actions/submit/pr_body.ts
@@ -40,16 +40,16 @@ export async function getPRBody(
       message: 'Body',
       choices: [
         {
-          title: `Edit Body (using ${context.userConfig.getEditor()})`,
-          value: 'edit',
-        },
-        {
           title: `Skip (${
             usePriorSubmitBody
               ? `use body from aborted submit`
               : skipDescription
           })`,
           value: 'skip',
+        },
+        {
+          title: `Edit Body (using ${context.userConfig.getEditor()})`,
+          value: 'edit',
         },
       ],
     });


### PR DESCRIPTION
# Summary

The PR body prompt showed "Edit Body" as the first/default option, requiring an extra keypress to skip.

Swapped the order so "Skip" is the default, since most submits don't need body edits.

# Stack

1. #25
1. #26
1. #27
1. #28
1. #29
1. #30
1. #31
1. #32 👈 